### PR TITLE
fix behavior of non-main branches in first push

### DIFF
--- a/fastfetch.go
+++ b/fastfetch.go
@@ -71,7 +71,7 @@ func NewFastFetch(
 	if err != nil {
 		return nil, err
 	}
-	rep, err := NewGoGitRepoWithStorage(remote)
+	rep, err := NewGoGitRepoWithStorage(remote, nil)
 	if err != nil {
 		return nil, err
 	}

--- a/testing.go
+++ b/testing.go
@@ -38,7 +38,7 @@ func (r *TestScratchRepo) Mkdir(t *testing.T, name string) {
 	require.NoError(t, err)
 }
 
-func (r *TestScratchRepo) inDir(t *testing.T, fn func() error) error {
+func (r *TestScratchRepo) InDir(t *testing.T, fn func() error) error {
 	cwd, err := os.Getwd()
 	require.NoError(t, err)
 	err = os.Chdir(r.dir)
@@ -73,7 +73,7 @@ func (g *GitError) Error() string {
 
 func (r *TestScratchRepo) GitWithErr(t *testing.T, args ...string) error {
 	r.setenv(t)
-	return r.inDir(t, func() error {
+	return r.InDir(t, func() error {
 		git, err := exec.LookPath("git")
 		require.NoError(t, err)
 		t.Logf("running git %v in %s", args, r.dir)


### PR DESCRIPTION
- for first push, pass down which branches we are pushing
- the first-pushed branch will be set to be the primary branch (not main necessarily)
- if we push multiple branches in the first push, the first of those branches alphabetically is the primary
- test this works in go-foks
- remove old hacky way of dealing with main vs master, since this technique is more general and cleaner
- new tests for pushing multiple non-main branches as our first act
